### PR TITLE
Fix external links with noopener noreferrer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -73,8 +73,8 @@
               <div class="dropdown">
                 <span>Projects</span>
                 <div class="dropdown-content">
-                  <a href="https://pausepal.app" target="_blank">Pause Pal</a>
-                  <a href="https://caliro.org" target="_blank">Caliro</a>
+                  <a href="https://pausepal.app" target="_blank" rel="noopener noreferrer">Pause Pal</a>
+                  <a href="https://caliro.org" target="_blank" rel="noopener noreferrer">Caliro</a>
                 </div>
               </div>
             </li>
@@ -84,8 +84,8 @@
               <div class="dropdown">
                 <span>Blogs</span>
                 <div class="dropdown-content">
-                  <a href="https://adityaaswani.substack.com/" target="_blank">Love Yourself Unconditionally</a>
-                  <a href="https://log.adityaaswani.com/" target="_blank">Gentle Velocity</a>
+                  <a href="https://adityaaswani.substack.com/" target="_blank" rel="noopener noreferrer">Love Yourself Unconditionally</a>
+                  <a href="https://log.adityaaswani.com/" target="_blank" rel="noopener noreferrer">Gentle Velocity</a>
                 </div>
               </div>
             </li>
@@ -180,7 +180,7 @@
         {%- else %}
         {%- set furl=get_url(path=i.url, trailing_slash=i.slash) %}
         {%- endif %}
-        <a class="rpad{%- if i.size %} {{ i.size }}{% endif %}" href="{{ furl | safe }}{%- if i.slash and uglyurls %}index.html{%- endif %}"{% if i.blank %} target="_blank"{% endif %}>{% if lang != config.default_language %} {{ macros::translate(key=i.name|safe, default=i.name|safe, i18n=i18n) }} {% else %} {{ i.name | safe }} {% endif %}</a>
+        <a class="rpad{%- if i.size %} {{ i.size }}{% endif %}" href="{{ furl | safe }}{%- if i.slash and uglyurls %}index.html{%- endif %}"{% if i.blank %} target="_blank" rel="noopener noreferrer"{% endif %}>{% if lang != config.default_language %} {{ macros::translate(key=i.name|safe, default=i.name|safe, i18n=i18n) }} {% else %} {{ i.name | safe }} {% endif %}</a>
         {%- endfor %}
       </nav>
       {%- endif %}
@@ -207,7 +207,7 @@
       {%- if config.extra.footer_credit_override %}
       {{ config.extra.footer_credit_override | safe }}
       {%- else %}
-      <p{%- if config.extra.footer_size %} class="{{ config.extra.footer_size }}"{% endif %}>{{ macros::translate(key="Powered_by", default="Powered by", i18n=i18n) }} <a href="https://www.getzola.org/" target="_blank">Zola</a> {{ macros::translate(key="and", default="and", i18n=i18n) }} <a href="https://github.com/jieiku/abridge/" target="_blank">Abridge</a></p>
+      <p{%- if config.extra.footer_size %} class="{{ config.extra.footer_size }}"{% endif %}>{{ macros::translate(key="Powered_by", default="Powered by", i18n=i18n) }} <a href="https://www.getzola.org/" target="_blank" rel="noopener noreferrer">Zola</a> {{ macros::translate(key="and", default="and", i18n=i18n) }} <a href="https://github.com/jieiku/abridge/" target="_blank" rel="noopener noreferrer">Abridge</a></p>
       {%- endif %}
       {%- endif %}
     </div>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -8,8 +8,8 @@
       <div class="dropdown">
         <span class="dropdown-toggle">Projects</span>
         <div class="dropdown-content">
-          <a href="https://pausepal.app" target="_blank">Pause Pal</a>
-          <a href="https://caliro.org" target="_blank">Caliro</a>
+          <a href="https://pausepal.app" target="_blank" rel="noopener noreferrer">Pause Pal</a>
+          <a href="https://caliro.org" target="_blank" rel="noopener noreferrer">Caliro</a>
         </div>
       </div>
     </li>
@@ -19,8 +19,8 @@
       <div class="dropdown">
         <span class="dropdown-toggle">Blog</span>
         <div class="dropdown-content">
-          <a href="https://adityaaswani.substack.com/" target="_blank">Love Yourself Unconditionally</a>
-          <a href="https://log.adityaaswani.com/" target="_blank">Gentle Velocity</a>
+          <a href="https://adityaaswani.substack.com/" target="_blank" rel="noopener noreferrer">Love Yourself Unconditionally</a>
+          <a href="https://log.adityaaswani.com/" target="_blank" rel="noopener noreferrer">Gentle Velocity</a>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to all `target="_blank"` links in navigation and footer

## Testing
- `zola build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a63d6c00948326bc6c9befdb6c13a6